### PR TITLE
Allow decimals in color-speed parameter

### DIFF
--- a/effects/color_spectrum.json
+++ b/effects/color_spectrum.json
@@ -3,11 +3,12 @@
     "script" : "color_spectrum.py",
     "args" :
     {
-        "brightness" : 1.0,
-        "reverse" : true,
+        "brightness" : 0.8,
+        "saturation" : 0.7,
+        "reverse" : false,
         "magnitude-min": 0.0,
         "magnitude-max": 100.0,
-        "color-speed": 0,
+        "color-speed": 0.05,
         "mirror": false,
         "start-index": 0,
         "band-width-exp": 5,

--- a/effects/color_spectrum.py
+++ b/effects/color_spectrum.py
@@ -32,6 +32,8 @@ class Effect(object):
         self.matrix = hyperion.args.get('matrix', False)
         self.debug = hyperion.args.get('debug', False)
 
+        self.color_progress = 0
+
         if self.mirror:
             print "Warning: 'mirror' mode needs a fix to flip the other side"
 
@@ -211,7 +213,13 @@ class Effect(object):
 
         ld = self._leds_data
         c = self._leds_data_center
-        i = abs(self.color_speed) * 3
+
+        i = abs(self.color_speed)
+        self.color_progress += i
+        if self.color_progress < 1:
+            return
+        i = int(self.color_progress)
+        self.color_progress = self.color_progress - i
         forward = self.color_speed > 0
         ld = self._leds_data
         l = len(ld)


### PR DESCRIPTION
I noticed that color_speed is quite high, so made a few changes to allow color-speed configuration to be a float value